### PR TITLE
Attempt at reverse method

### DIFF
--- a/src/dotize.js
+++ b/src/dotize.js
@@ -65,6 +65,81 @@ dotize.convert = function(obj, prefix) {
     }(obj, prefix, true);
 };
 
+dotize.revert = function (source) {
+
+  function arrayRecurse(parent, key, value) {
+    var subkey, index;
+    if (key.indexOf('].') !== -1) {
+      index = key.slice(key.lastIndexOf('[')+1, key.lastIndexOf('].'));
+      subkey = key.slice(key.lastIndexOf('].')+2);
+      parent[index] = keyRecurse(parent[index] || {}, subkey, value);
+      return parent;
+    }
+    if (key.lastIndexOf('[') === 0) {
+      parent.push(value);
+      return parent;
+    }
+    subkey = key.slice(0, key.lastIndexOf('['));
+    index = parseInt(subkey.slice(1, subkey.length-1));
+    parent[index] = arrayRecurse(parent[index] || [], subkey, value);
+    return parent;
+  }
+  
+  function keyRecurse (parent, key, value) {
+    if (key.indexOf('.') === -1) {
+      parent[key] = value;
+      return parent;
+    }
+    var subkey = key.slice(0, key.indexOf('.'));
+    parent[subkey] = keyRecurse(parent[subkey] || {}, key.slice(key.indexOf('.')+1), value);
+    return parent;
+  };
+  
+  var result;
+  result = {};  // Has to be a hash
+  Object.keys(source).forEach(function (sourceKey) {  
+    var sourceValue = source[sourceKey];
+    
+    if (sourceKey.indexOf('[') === -1) 
+      // Simple case
+      keyRecurse(result, sourceKey, sourceValue);
+    else {
+      // Complicated case
+      // We make values from outside in, figuring out which one to send it to
+      // Assume there's only one [] for now, and it's at the end
+      var step;
+      step = function cycle (parent, key, value) {
+        var subkey, lastSubkey, restKey, index, nextIndex, nextKey;
+        if (key.indexOf('[') != key.lastIndexOf('[')) {  // what about object array array object?    
+          subkey = key.slice(0, key.indexOf('['));
+          restKey = key.slice(key.indexOf(']')+1);
+          index = parseInt(key.slice(key.indexOf('[')+1, key.indexOf(']')));
+          if (restKey[0] == '.') {
+            // redo value so that it's the result of a key recurse
+            // need to get the index, label it as a key originally
+            index = parseInt(key.slice(key.indexOf('[')+1, key.indexOf(']')));
+            nextKey = restKey.slice(1, restKey.indexOf('['));
+            parent[subkey][index] = parent[subkey][index] || {};
+            parent[subkey][index][nextKey] = arrayRecurse(parent[subkey][index][nextKey] || [], restKey.slice(1), value);
+          } else {
+            // do nothing
+          }
+        }
+        subkey = key.slice(0, key.indexOf('['));
+        restKey = key.slice(key.indexOf('['));  // key to assign
+        parent[subkey] = parent[subkey] || [];
+        return arrayRecurse(parent[subkey], restKey, value);
+      }(result, sourceKey, sourceValue);
+      keyRecurse(result, sourceKey.slice(0, sourceKey.indexOf('[')), step);      
+    }
+  });
+  
+  if ((Object.keys(result).length == 1) && result[""])
+    return result[""];
+  return result;
+}
+
+
 if (typeof module != "undefined") {
     module.exports = dotize;
 }


### PR DESCRIPTION
I've already gotten quite a bit complete, am attempting to come up with a complete solution (also happy to be told I'm doing this the wrong way). No unit tests?

Tested and passes with following cases:

from: `{"this.has.nothing": 0, "this.has.string": 'string'}`
to: `{"this": {"has": {"string": 'string', "nothing": 0}}}`

from: `{"independent": 'value', "first.second": 'yo', "first.third": 'hello', 'parent_ids[0][0]': 2, 'parent_ids[0][1]': 100}`
to: `{independent: 'value', first: {second: 'yo', third: 'hello'}, parent_ids: [[2, 100]]}`

from: `{"parents[0].name.firstName": "Adam", "parents[0].name.lastName": "Morris"}`
to: `{parents: [{name: {firstName: 'Adam', lastName: 'Morris'}}]}`

from: `{"[0]": 1, "[1]": 2, "[2][0]": 3, "[2][1]": 4, "[3]": 5}`
to: `[1, 2, [3, 4], 5]`

from: `{"parents[0]": 1, "parents[1]": 2, "parents[2].telephones[0].prefix": 3, "parents[2].telephones[0].postfix": 4, "parents[3]": 5}`
to: `{"parents":[1,2, {"telephones":[{"prefix":3,"postfix":4}]},5]}`

Fails with:
`{"parents[0]": 1, "parents[1]": 2, "parents[2].tele.phones[0].prefix": 3, "parents[2].tele.phones[0].postfix": 4, "parents[3]": 5}`
expects: `{"parents":[1,2, {"tele": {"phones":[{"prefix":3,"postfix":4}]}},5]}`

`{"parents[0]": 1, "parents[1]": 2, "parents[2][0].prefix": 3, "parents[2][0].postfix": 4, "parents[3]": 5}`
expects: `{"parents":[1,2, [{"prefix":3,"postfix":4}], 5]}`